### PR TITLE
Calculated properties for select columns in `ExecuteBulkInsertAsync`

### DIFF
--- a/DapperBulkQueries.Common/QueryGeneratorBase.cs
+++ b/DapperBulkQueries.Common/QueryGeneratorBase.cs
@@ -148,7 +148,7 @@ public abstract class QueryGeneratorBase
             sqlBuilder.AppendLine($" WHERE {string.Join(" AND ", selectorColumnNames.Select(p => $"{p} = @{paramPrefix}{p}_{i}"))};");
             foreach (var propertyName in selectorColumnNames)
             {
-                var value = rowObjects[i].GetType().GetProperty(propertyName).GetValue(rowObjects[i]);
+                var value = GetPropertyValue(propertyName, rowObjects[i], calculatedProperties);
                 parameters.Add($"@{paramPrefix}{propertyName}_{i}", value);
             }
         }

--- a/DapperBulkQueries.Tests/Models/TestTableToMap.cs
+++ b/DapperBulkQueries.Tests/Models/TestTableToMap.cs
@@ -1,0 +1,9 @@
+﻿namespace DapperBulkQueries.Tests.Models;
+
+public class TestTableToMap
+{
+    public long ElementId { get; init; }
+    public required string ElementText { get; init; }
+    public decimal ElementNumber { get; init; }
+    public bool ElementBool { get; init; }
+}

--- a/DapperBulkQueries.Tests/SqlServerTests.cs
+++ b/DapperBulkQueries.Tests/SqlServerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using DapperBulkQueries.Tests.Models;
 
 namespace DapperBulkQueries.Tests;
 
@@ -210,6 +211,52 @@ public class SqlServerTests : IDisposable
         Assert.Equal(3, changedRows?.Count());
         Assert.Equal("Updated first", changedRows[0].TextCol);
         Assert.Equal("Updated second", changedRows?[1].TextCol);
+        Assert.Equal(5, changedRows[0].NumberCol);
+        Assert.Equal(6, changedRows[1].NumberCol);
+        Assert.True(changedRows[2].IsPropertiesMatch(sampleData[2]),
+            "Rows were updated but another row changed too");
+    }
+
+    [Fact]
+    public async Task ExecuteBulkUpdateAsync_ExpectRowsChanged_MapColumns()
+    {
+        await using var conn = await ConnectionHelper.GetOpenSqlServerConnectionAsync();
+        var sampleData = SampleDataHelper.GetSampleTestTablesWithoutId1();
+
+        // Insert data
+        await conn.ExecuteBulkInsertAsync(
+            "TestTable", sampleData, ["TextCol", "NumberCol", "BoolCol"]);
+
+        var updateData = new List<TestTableToMap>()
+        {
+            new () { ElementId = 1, ElementText = "Updated first", ElementNumber = 5, ElementBool = true },
+            new () { ElementId = 2, ElementText = "Updated second", ElementNumber = 6, ElementBool = false }
+        };
+
+        var propertyMap = new Dictionary<string, Func<TestTableToMap, object>>()
+        {
+            { "Id", (entity) => entity.ElementId },
+            { "BoolCol", (entity) => entity.ElementBool },
+            { "TextCol", (entity) => entity.ElementText },
+            { "NumberCol", (entity) => entity.ElementNumber },
+        };
+
+        await conn.ExecuteBulkUpdateAsync(
+            "TestTable",
+            updateData,
+            ["Id", "BoolCol"], // Update where ID AND BoolCol match
+            ["TextCol", "NumberCol"],  // Properties to update
+            calculatedProperties: propertyMap,
+            useTransaction: false);
+
+        // Retrieve the data in its current form
+        var changedRows = (await conn.QueryAsync<TestTable>("SELECT * FROM TestTable ORDER BY Id")).ToList();
+
+        // Validate
+        Assert.NotNull(changedRows);
+        Assert.Equal(3, changedRows.Count);
+        Assert.Equal("Updated first", changedRows[0].TextCol);
+        Assert.Equal("Updated second", changedRows[1].TextCol);
         Assert.Equal(5, changedRows[0].NumberCol);
         Assert.Equal(6, changedRows[1].NumberCol);
         Assert.True(changedRows[2].IsPropertiesMatch(sampleData[2]),


### PR DESCRIPTION
TL;DR: `calculatedProperties` dictionary is also parsed for `selectorColumnNames`. This allows arbitrary names for any property of the`rowObjects` items, not just the "output" ones.

### Changes

- In `GenerateBulkUpdate`, we use `GetPropertyValue` to compute values for `selectorColumnNames`
- Added unit test for both Postgres and SqlServer

### Detailed explanation

It is quite common to have a POCO class where the property names do not match with the respective column names. 
The `calculatedProperties` parameter allows to overcome this limitation, without having to define specialized "db-oriented" classes, mapping from other POCOs, etc.

However, this feature is limited to the columns that we are targeting for update / insertion, meaning that we can't map the `selectorColumns` in the `calculatedProperties` dictionary and expect it to work.

This PR modifies `QueryGeneratorBase.GenerateBulkUpdate` so that `GetPropertyValue` gets called when processing `selectorColumnNames`, allowing users to use POCOs with arbitrary property names.